### PR TITLE
Avoid error messages in build_trebleshot.sh

### DIFF
--- a/build_trebleshot.sh
+++ b/build_trebleshot.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 BUILD="release"  # release, debug
-if ["$1"]; then
+if [ -n "$1" ]; then
 	BUILD="$1"
 fi
 echo "Building: $BUILD"
-mkdir "cmake-build-$BUILD"
+mkdir -p "cmake-build-$BUILD"
 cd "cmake-build-$BUILD"
 eval `qtchooser -qt=5 -print-env | grep QTLIBDIR`
 cmake -DQTLIBDIR="$QTLIBDIR" -DCMAKE_BUILD_TYPE=$BUILD -G "CodeBlocks - Unix Makefiles" ..


### PR DESCRIPTION
When I tried running `./build_trebleshot.sh` on my Ubuntu 19.04, I got this message:

    ./build_trebleshot.sh: 3: ./build_trebleshot.sh: []: not found

I fixed that by using `-n` (try typing `help test` on your bash shell to read the documentation).

Upon running the script again, it prints:

    mkdir: cannot create directory ‘cmake-build-release’: File exists

Which can be easily suppressed by passing `-p` to `mkdir`.